### PR TITLE
Use parse tree

### DIFF
--- a/src/JuliaSyntaxHighlighting.jl
+++ b/src/JuliaSyntaxHighlighting.jl
@@ -201,6 +201,10 @@ By default, `JuliaSyntax.parseall` is used to generate to `ast` with the
 `ignore_errors` keyword argument set to `true`. Alternatively, one may provide a
 pre-generated `ast`.
 
+!!! warning
+    Note that the particular faces used by `JuliaSyntax`, and the way they
+    are applied, is subject to change.
+
 # Examples
 
 ```jldoctest
@@ -239,6 +243,10 @@ Modify `content` by applying syntax highlighting using `JuliaSyntax`.
 By default, `JuliaSyntax.parseall` is used to generate to `ast` with the
 `ignore_errors` keyword argument set to `true`. Alternatively, one may provide a
 pre-generated `ast`.
+
+!!! warning
+    Note that the particular faces used by `JuliaSyntax`, and the way they
+    are applied, is subject to change.
 
 # Examples
 


### PR DESCRIPTION
Previously we were just using the Tokenizer from JuliaSyntax, but we might as well use the full parse-tree. It's higher-quality data, and with just a little more work we can have much more accurate highlighting.

Subject to change as I work on this, but here's a before and after screenshot for the current progress:

### Before

![image](https://github.com/JuliaLang/JuliaSyntaxHighlighting.jl/assets/20903656/a758ed1a-e79a-47b4-81f1-88926f60ec9a)

### After

![image](https://github.com/JuliaLang/JuliaSyntaxHighlighting.jl/assets/20903656/fec85e20-fbcc-49a4-b7ab-29303d3ce663)

### Specific showcases

![image](https://github.com/JuliaLang/JuliaSyntaxHighlighting.jl/assets/20903656/522f9f90-466d-4384-8aac-0a2c42f08c1a)
