### PR TITLE
Highlight the label of labeled break/continue

### DIFF
--- a/src/JuliaSyntaxHighlighting.jl
+++ b/src/JuliaSyntaxHighlighting.jl
@@ -99,6 +99,7 @@ const HIGHLIGHT_FACES = [
     :julia_comparator => Face(inherit=:julia_operator),
     :julia_assignment => Face(),
     :julia_keyword => Face(foreground=:red),
+    :julia_label => Face(inherit=:julia_keyword),
     :julia_parentheses => Face(),
     :julia_unpaired_parentheses => Face(inherit=[:julia_error, :julia_parentheses]),
     :julia_error => Face(background=:red),
@@ -288,6 +289,18 @@ function _hl_annotations!(highlights::Vector{@NamedTuple{region::UnitRange{Int},
         end
     elseif nkind == K";" && pkind == K"parameters" && pnode == lnode
         :julia_assignment
+    elseif nkind in (K"break", K"continue") && numchildren(node) > 0
+        # The label of a labeled `break`/`continue` is its first non-trivia
+        # child. Highlight it so it stands apart from a juxtaposed value
+        # expression, as in `break label val`.
+        label = findfirst(
+            c -> !JuliaSyntax.is_trivia(c),
+            something(children(node), typeof(node)[]))
+        if !isnothing(label) && kind(node[label]) == K"Identifier"
+            shift = sum(c -> Int(span(c)), node[1:label-1], init=0)
+            region = first(region)+shift:first(region)+shift+Int(span(node[label]))-1
+            :julia_label
+        end
     elseif (JuliaSyntax.is_keyword(nkind) ||nkind == K"->" ) && JuliaSyntax.is_trivia(node)
         :julia_keyword
     elseif nkind == K"where"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,6 +30,16 @@ astr_sum1to8 = Base.AnnotatedString("sum(1:8)")
 # Check for string indexing issues
 @test Base.annotations(highlight(":π")) |> first |> first == 1:3
 
+# Test that labeled break/continue labels are highlighted, but not the
+# (possibly juxtaposed) break value
+labeled_break = highlight("@label x begin\n  break x i * 3\nend")
+anns = Base.annotations(labeled_break)
+@test any(a -> a.region == 24:24 && a.value == :julia_label, anns)
+@test all(a -> a.value != :julia_label || a.region == 24:24, anns)
+@test any(a -> a.region == 10:14 && a.value == :julia_label,
+          Base.annotations(highlight("continue outer")))
+@test all(a -> a.value != :julia_label, Base.annotations(highlight("break")))
+
 # Test unpaired parentheses (issue #17)
 # Test consecutive unpaired closing parens and that depth counter resets properly
 reset_after_unpaired = highlight("(()))) ()")


### PR DESCRIPTION
Labeled `break`/`continue` (JuliaLang/julia#60481) juxtaposes the label with an optional value expression, as in `break x i * 3`, which is hard to read with uniform identifier styling. Highlight the label (the first non-trivia child of the `break`/`continue` node) with a new `julia_label` face that inherits from `julia_keyword`, so the label reads as part of the `break` rather than as the start of the value expression.